### PR TITLE
fix: update repo links to use bluetooth-devices

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: ["bdraco"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Feature
 
-- Add mappings for gzip module (#3) ([`058cfa8`](https://github.com/bdraco/zlib-fast/commit/058cfa8b7f75fea0ef3f98faef1a9d6a469eae72))
+- Add mappings for gzip module (#3) ([`058cfa8`](https://github.com/bluetooth-devices/zlib-fast/commit/058cfa8b7f75fea0ef3f98faef1a9d6a469eae72))
 
 ## v0.1.0 (2024-01-27)
 
 ### Feature
 
-- First version (#1) ([`72f0ee7`](https://github.com/bdraco/zlib-fast/commit/72f0ee70df6bbd976aff1971f5ddbb0fae2924a9))
+- First version (#1) ([`72f0ee7`](https://github.com/bluetooth-devices/zlib-fast/commit/72f0ee70df6bbd976aff1971f5ddbb0fae2924a9))
 
 ## v0.0.0 (2024-01-27)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,4 +114,4 @@ $ pytest tests
 
 The deployment should be automated and can be triggered from the Semantic Release workflow in GitHub. The next version will be based on [the commit logs](https://python-semantic-release.readthedocs.io/en/latest/commit-log-parsing.html#commit-log-parsing). This is done by [python-semantic-release](https://python-semantic-release.readthedocs.io/en/latest/index.html) via a GitHub action.
 
-[gh-issues]: https://github.com/bdraco/zlib-fast/issues
+[gh-issues]: https://github.com/bluetooth-devices/zlib-fast/issues

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # zlib-fast
 
 <p align="center">
-  <a href="https://github.com/bdraco/zlib-fast/actions/workflows/ci.yml?query=branch%3Amain">
-    <img src="https://img.shields.io/github/actions/workflow/status/bdraco/zlib-fast/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
+  <a href="https://github.com/bluetooth-devices/zlib-fast/actions/workflows/ci.yml?query=branch%3Amain">
+    <img src="https://img.shields.io/github/actions/workflow/status/bluetooth-devices/zlib-fast/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
   </a>
   <a href="https://zlib-fast.readthedocs.io">
     <img src="https://img.shields.io/readthedocs/zlib-fast.svg?logo=read-the-docs&logoColor=fff&style=flat-square" alt="Documentation Status">
   </a>
-  <a href="https://codecov.io/gh/bdraco/zlib-fast">
-    <img src="https://img.shields.io/codecov/c/github/bdraco/zlib-fast.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
+  <a href="https://codecov.io/gh/bluetooth-devices/zlib-fast">
+    <img src="https://img.shields.io/codecov/c/github/bluetooth-devices/zlib-fast.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
   </a>
 </p>
 <p align="center">
@@ -34,7 +34,7 @@
 
 **Documentation**: <a href="https://zlib-fast.readthedocs.io" target="_blank">https://zlib-fast.readthedocs.io </a>
 
-**Source Code**: <a href="https://github.com/bdraco/zlib-fast" target="_blank">https://github.com/bdraco/zlib-fast </a>
+**Source Code**: <a href="https://github.com/bluetooth-devices/zlib-fast" target="_blank">https://github.com/bluetooth-devices/zlib-fast </a>
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A wrapper to use the fastest available zlib"
 authors = ["J. Nick Koston <nick@koston.org>"]
 license = "Apache Software License 2.0"
 readme = "README.md"
-repository = "https://github.com/bdraco/zlib-fast"
+repository = "https://github.com/bluetooth-devices/zlib-fast"
 documentation = "https://zlib-fast.readthedocs.io"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -19,8 +19,8 @@ packages = [
 ]
 
 [tool.poetry.urls]
-"Bug Tracker" = "https://github.com/bdraco/zlib-fast/issues"
-"Changelog" = "https://github.com/bdraco/zlib-fast/blob/main/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/bluetooth-devices/zlib-fast/issues"
+"Changelog" = "https://github.com/bluetooth-devices/zlib-fast/blob/main/CHANGELOG.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
I have been transferring some of the projects that are under my person GitHub to OHF repos since it was hard for other contributors to help out with projects that were hosted on my personal GitHub. Bluetooth-devices has a lot of people I trust so I picked that org even though the fit is a bit strange.  We could later transfer it to home-assistant-libs if desired.